### PR TITLE
Refactoring around configuration and event sinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Tested on an Amazon EC2 Small with Siege, SnowCannon handles up to about 10,000 
 ## Roadmap
 
 * Update the output format (turn it into JSON)
-* Add Fluentd sink support
+* Add Fluentd event sink support
 * Work on supporting infrastructure of auto-scaling and load balancing
 
 ## Copyright and license

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ SnowCannon currently supports two different event sinks:
 
 Another event sink planned (but not yet implemented) is [Fluentd] [fluentd] - where Fluentd will be responsible for uploading the events to S3, Google Storage or equivalent.
 
-You can configure your event sink in the `config.js` file. By default the event sink is set to **stdout**. To change it to **S3**, please set the `sink.out` variable like so:
+You can configure your event sink in the `config.js` file. By default the event sink is set to **stdout**. To change it to **s3**, please set the `sink.out` variable like so:
 
     config.sink.out = "s3";
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ Tested on an Amazon EC2 Small with Siege, SnowCannon handles up to about 10,000 
 
 ## Roadmap
 
-* Update the output format
+* Update the output format (turn it into JSON)
+* Add Fluentd sink support
 * Work on supporting infrastructure of auto-scaling and load balancing
 
 ## Copyright and license

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ To check this is working:
 
 SnowCannon currently supports two different event sinks:
 
-1. **stdout** - where events (and only events) are printed to `stdout`. You can then use your process control system (e.g. supervisord, daemontools or Angel) to handle the `stdout` eventstream (e.g. uploading it to S3 or Google Storage). This sink is also useful for debugging
+1. **stdout** - where events (and only events) are printed to `stdout`. You can then use your process control system (e.g. supervisord or daemontools) to handle the `stdout` eventstream (e.g. uploading it to S3 or Google Storage). This sink is also useful for debugging
 2. **s3** - where events are collected by SnowCannon, and then regularly gzipped and uploaded to S3 by SnowCannon itself
 
 Another event sink planned (but not yet implemented) is [Fluentd] [fluentd] - where Fluentd will be responsible for uploading the events to S3, Google Storage or equivalent.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ To check this is working:
 
 SnowCannon currently supports two different event sinks:
 
-1. **stdout** - where events (and only events) are printed to `stdout`. You can then use your process control system (e.g. supervisord, daemontools or Angel) to handle the `stdout` eventstream (e.g. gzipping it and uploading it to S3 or Google Storage). This is also useful for debugging
+1. **stdout** - where events (and only events) are printed to `stdout`. You can then use your process control system (e.g. supervisord, daemontools or Angel) to handle the `stdout` eventstream (e.g. uploading it to S3 or Google Storage). This sink is also useful for debugging
 2. **s3** - where events are collected by SnowCannon, and then regularly gzipped and uploaded to S3 by SnowCannon itself
 
 Another event sink planned (but not yet implemented) is [Fluentd] [fluentd] - where Fluentd will be responsible for uploading the events to S3, Google Storage or equivalent.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ SnowCannon currently supports two different event sinks:
 
 Another event sink planned (but not yet implemented) is [Fluentd] [fluentd] - where Fluentd will be responsible for uploading the events to S3, Google Storage or equivalent.
 
-You can configure your event sink in the `config.js` file. By default the event sink is set to **stdout**. To change it to **s3**, please set the `sink.out` variable like so:
+You can configure your event sink in the `config.js` file. By default the event sink is set to **stdout**. To change it to **s3**, please set the `config.sink.out` variable like so:
 
     config.sink.out = "s3";
 

--- a/README.md
+++ b/README.md
@@ -40,16 +40,6 @@ Next, install the dependent modules:
 
     $ npm install knox node-uuid
 
-Plug your S3 credentials and a bucket name into the config section:
-
-```javascript
-logBucket: {
-		key: 'KEY GOES HERE',
-		secret: 'SECRET GOES HERE',
-		bucket: 'S3 BUCKET NAME GOES HERE'
-	},
-```
-
 And finally run it:
 
     $ node snowcannon.js
@@ -62,7 +52,33 @@ You can run a manual check on SnowCannon by loading the following web page in yo
 
     tests/manual/async.html
 
-Use e.g. Chrome Developer Tools to check that `ice.png` is being successfully fetched from your SnowCannon instance running on `http://localhost`.
+To check this is working:
+
+1. Use e.g. Chrome Developer Tools to check that `ice.png` is being successfully fetched from your SnowCannon instance running on `http://localhost`.
+2. Check that your events are being printed to `stdout` in your terminal running SnowCannon
+
+## Configuring your event sink
+
+SnowCannon currently supports two different event sinks:
+
+1. **stdout** - where events (and only events) are printed to `stdout`. You can then use your process control system (e.g. supervisord, daemontools or Angel) to handle the stdout eventstream (e.g. gzipping it and uploading it to S3 or Google Storage). This is also useful for debugging
+2. **s3** - where events are collected by SnowCannon, and then regularly gzipped and uploaded to S3 by SnowCannon itself
+
+Another event sink planned (but not yet implemented) is [Fluentd] [fluentd] - where Fluentd will be responsible for uploading the events to S3, Google Storage or equivalent.
+
+You can configure your event sink in the `config.js` file. By default the event sink is set to **stdout**. To change it to **S3**, please set the `sink.out` variable like so:
+
+    config.sink.out = "s3";
+
+And then update the following configuration section:
+
+	config.sink.s3.bucket = 'S3 BUCKET NAME GOES HERE';
+
+	// AWS access details
+	config.sink.s3.key = process.env.AWS_ACCESS_KEY_ID || 'KEY GOES HERE IF ENV NOT SET';
+	config.sink.s3.secret = process.env.AWS_SECRET_KEY || 'SECRET GOES HERE IF ENV NOT SET';
+
+Note that you do not have to add your AWS access details into this file if they are already available to node.js in your shell environment.
 
 ## Performance
 
@@ -92,3 +108,4 @@ limitations under the License.
 [node-uuid]: https://github.com/broofa/node-uuid
 [license]: http://www.apache.org/licenses/LICENSE-2.0
 [node-install]: https://github.com/joyent/node/wiki/Installing-Node.js-via-package-manager
+[fluentd]: http://fluentd.org/

--- a/README.md
+++ b/README.md
@@ -68,16 +68,20 @@ Another event sink planned (but not yet implemented) is [Fluentd] [fluentd] - wh
 
 You can configure your event sink in the `config.js` file. By default the event sink is set to **stdout**. To change it to **s3**, please set the `config.sink.out` variable like so:
 
-    config.sink.out = "s3";
+```javascript
+config.sink.out = "s3";
+```
 
 And then update the following configuration section:
 
-	// S3 bucket name
-	config.sink.s3.bucket = 'S3 BUCKET NAME GOES HERE';
+```javascript
+// S3 bucket name
+config.sink.s3.bucket = 'S3 BUCKET NAME GOES HERE';
 
-	// AWS access details
-	config.sink.s3.key = process.env.AWS_ACCESS_KEY_ID || 'KEY GOES HERE IF ENV NOT SET';
-	config.sink.s3.secret = process.env.AWS_SECRET_KEY || 'SECRET GOES HERE IF ENV NOT SET';
+// AWS access details
+config.sink.s3.key = process.env.AWS_ACCESS_KEY_ID || 'KEY GOES HERE IF ENV NOT SET';
+config.sink.s3.secret = process.env.AWS_SECRET_KEY || 'SECRET GOES HERE IF ENV NOT SET';
+```
 
 Note that you do not have to add your AWS access details into this file if they are already available to node.js in your shell environment.
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ You can configure your event sink in the `config.js` file. By default the event 
 
 And then update the following configuration section:
 
+	// S3 bucket name
 	config.sink.s3.bucket = 'S3 BUCKET NAME GOES HERE';
 
 	// AWS access details

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ To check this is working:
 
 SnowCannon currently supports two different event sinks:
 
-1. **stdout** - where events (and only events) are printed to `stdout`. You can then use your process control system (e.g. supervisord, daemontools or Angel) to handle the stdout eventstream (e.g. gzipping it and uploading it to S3 or Google Storage). This is also useful for debugging
+1. **stdout** - where events (and only events) are printed to `stdout`. You can then use your process control system (e.g. supervisord, daemontools or Angel) to handle the `stdout` eventstream (e.g. gzipping it and uploading it to S3 or Google Storage). This is also useful for debugging
 2. **s3** - where events are collected by SnowCannon, and then regularly gzipped and uploaded to S3 by SnowCannon itself
 
 Another event sink planned (but not yet implemented) is [Fluentd] [fluentd] - where Fluentd will be responsible for uploading the events to S3, Google Storage or equivalent.

--- a/config.js
+++ b/config.js
@@ -1,0 +1,68 @@
+var config = {};
+
+config.server = {};
+config.cookie = {};
+
+config.sink = {};
+config.sink.s3 = {};
+config.sink.fluentd = {};
+
+/**
+ * Server configuration
+ */
+
+// HTTP port
+config.server.httpPort = 80;
+
+/**
+ * Cookie configuration
+ */
+
+// Number of milliseconds the cookie will stay around
+config.cookie.milliseconds = 31556900000;
+
+// If defined, sets the domain name cookies will be set on.
+// Can be a wildcard e.g. '.foo.com'
+// If undefined it'll just use the FQDN of the host
+config.cookie.domainName = undefined;
+
+/**
+ * Which sink will we use for collected events?
+ * - s3 means SnowCannon will handle compression and upload to S3 itself
+ * - stdout means SnowCannon will log events to stdout. Use your process control system (e.g. supervisord, daemontools, Angel) to handle the stdout eventstream
+ * - fluentd means SnowCannon will use Fluentd (http://fluentd.org/) to log events. NOT YET SUPPORTED
+ */
+config.sink.out = "stdout"; // Or "s3" or "fluentd" (not yet supported)
+
+/*
+ * S3 configuration
+ */
+
+// How often to push data to S3
+config.sink.s3.flushSeconds = 20;
+
+// S3 bucket
+config.sink.s3.bucket = 'S3 BUCKET NAME GOES HERE';
+
+// AWS access details
+config.sink.s3.key = process.env.AWS_ACCESS_KEY_ID || 'KEY GOES HERE IF ENV NOT SET';
+config.sink.s3.secret = process.env.AWS_SECRET_KEY || 'SECRET GOES HERE IF ENV NOT SET';
+
+/**
+ * Fluentd configuration
+ * NOT YET SUPPORTED
+ */
+
+// Host running Fluentd daemon
+config.sink.fluentd.host = "localhost";
+
+// Port for Fluentd daemon
+config.sink.fluentd.port = 24224;
+
+// Timeout for contacting the Fluentd daemon
+config.sink.fluentd.timeout = 3.0;
+
+/**
+ * All important export of config.
+ */
+module.exports = config;

--- a/config.js
+++ b/config.js
@@ -41,7 +41,7 @@ config.sink.out = "stdout"; // Or "s3" or "fluentd" (not yet supported)
 // How often to push data to S3
 config.sink.s3.flushSeconds = 600;
 
-// S3 bucket
+// S3 bucket name
 config.sink.s3.bucket = 'S3 BUCKET NAME GOES HERE';
 
 // AWS access details

--- a/config.js
+++ b/config.js
@@ -32,7 +32,7 @@ config.cookie.domainName = undefined;
  * - stdout means SnowCannon will log events to stdout. Use your process control system (e.g. supervisord, daemontools, Angel) to handle the stdout eventstream
  * - fluentd means SnowCannon will use Fluentd (http://fluentd.org/) to log events. NOT YET SUPPORTED
  */
-config.sink.out = "stdout"; // Or "s3" or "fluentd" (not yet supported)
+config.sink.out = "stdout"; // Or "s3". "fluentd" NOT YET SUPPORTED
 
 /*
  * S3 configuration

--- a/config.js
+++ b/config.js
@@ -39,7 +39,7 @@ config.sink.out = "stdout"; // Or "s3" or "fluentd" (not yet supported)
  */
 
 // How often to push data to S3
-config.sink.s3.flushSeconds = 20;
+config.sink.s3.flushSeconds = 600;
 
 // S3 bucket
 config.sink.s3.bucket = 'S3 BUCKET NAME GOES HERE';

--- a/libs/s3-sink.js
+++ b/libs/s3-sink.js
@@ -1,0 +1,55 @@
+var uuid = require('node-uuid');
+var knox = require('knox');
+var zlib = require('zlib');
+
+var s3Sink = {};
+
+// To identify this server's files.
+var uniqueName = uuid.v4();
+
+// Log file array for S3
+var s3Log = [];
+
+/**
+ * "Logs" an event by pushing it to our s3Log array
+ */ 
+s3Sink.log = function(event) {
+	s3Log.push(event);	
+}
+
+/**
+ * Gzips and uploads our s3Log array to S3.
+ */
+s3Sink.upload = function(config) {
+	if (s3Log.length > 0) {
+		var client = knox.createClient(config);
+
+		// TODO: is this a race condition?
+		var outputLog = JSON.stringify(s3Log);
+		console.log('Sending ' + s3Log.length + ' events to S3');
+		s3Log = [];
+
+		// Gzip the output
+		zlib.gzip(outputLog, function(err, buffer) {
+			if (!err) {
+				var date = new Date();
+				var req = client.put(uniqueName + '-' + date.toISOString() + '.json.gz', {
+					'Content-Length': buffer.length,
+			 		'Content-Type': 'application/gzip'
+				});
+
+				req.on('response', function(res){
+					if (200 == res.statusCode) {
+						console.log('saved to %s', req.url);
+		 			}
+				});
+				req.end(buffer);	
+			}
+		});
+	}
+}
+
+/**
+ * All important export of s3Sink.
+ */
+module.exports = s3Sink;


### PR DESCRIPTION
Summary of changes:
1. Broke out configuration into separate file
2. Broke out S3 event sink behaviour into separate file
3. Added stdout-based event sink
4. Stubbed configuration for Fluentd (http://fluentd.org/) event sink

The rationale for adding an stdout sink:
1. Useful for getting started and debugging
2. Some sysadmins will wrap SnowCannon in a daemontools/supervisord or equivalent and use that monitoring tool to manage logs via stdout

The rationale for stubbing Fluentd support and moving the S3 sink into a standalone module:
- Better separation of concerns between collector and uploader
- Using Fluentd, SnowCannon should be more performant (as not also running gzips and S3 uploads)
- Fluentd supports many more storage destinations than just S3 - see http://fluentd.org/plugin/ 
- Using Fluentd, SnowCannon cannot be crashed by unexpected AWS/gzip behaviour
